### PR TITLE
Use @Valid to trigger request body validation

### DIFF
--- a/src/main/kotlin/com/exemplo/demo/controller/SaudacaoController.kt
+++ b/src/main/kotlin/com/exemplo/demo/controller/SaudacaoController.kt
@@ -3,9 +3,9 @@ package com.exemplo.demo.controller
 import org.springframework.context.MessageSource
 import org.springframework.context.i18n.LocaleContextHolder
 import org.springframework.http.ResponseEntity
-import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
 import com.exemplo.demo.dto.UserDto
+import jakarta.validation.Valid
 
 @RestController
 @RequestMapping("/api")
@@ -19,7 +19,7 @@ class SaudacaoController(private val messages: MessageSource) {
     }
 
     @PostMapping("/users")
-    fun create(@Validated @RequestBody dto: UserDto): ResponseEntity<Any> {
+    fun create(@Valid @RequestBody dto: UserDto): ResponseEntity<Any> {
         val locale = LocaleContextHolder.getLocale()
         val msg = messages.getMessage("user.created", arrayOf(dto.name), locale)
         return ResponseEntity.ok(mapOf("message" to msg))


### PR DESCRIPTION
## Summary
- Replace `@Validated` with `@Valid` on user creation endpoint to ensure Bean Validation executes

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.3)*

------
https://chatgpt.com/codex/tasks/task_e_68a59689f4f88322bc4687f38826bfb9