### PR TITLE
Corrige termo api-version no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ src/
 
 ## 2) `pom.xml` (copie e cole)
 
-> Inclui **kotlin-maven-allopen** para habilitar `<plugin>spring</plugin>` e fixa **language/api 2.0** (evita o erro `api-version > language-version`).
+> Inclui **kotlin-maven-allopen** para habilitar `<plugin>spring</plugin>` e fixa **language/api 2.0**
+> (evita o erro `api-version > language-version`).
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary
- Ajusta descrição para mostrar `api-version` como palavra única e manter mensagem sobre o erro `api-version > language-version`

## Testing
- `mvn -q test` *(falhou: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a59880ee0883229d30f09de5d3aecf