### PR TITLE
Align bad request response status with HttpStatus

### DIFF
--- a/src/main/kotlin/com/exemplo/demo/RestExceptionHandler.kt
+++ b/src/main/kotlin/com/exemplo/demo/RestExceptionHandler.kt
@@ -22,7 +22,7 @@ class RestExceptionHandler {
         }
         val body = mapOf(
             "timestamp" to Instant.now().toString(),
-            "status" to 400,
+            "status" to HttpStatus.BAD_REQUEST.value(),
             "errors" to errors
         )
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body)


### PR DESCRIPTION
## Summary
- Replace hardcoded status code with `HttpStatus.BAD_REQUEST.value()` in validation error handler

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5989c2e548322b31b77430a21cb78