### PR TITLE
Add SaudacaoController i18n tests

### DIFF
--- a/src/test/kotlin/com/exemplo/demo/controller/SaudacaoControllerTest.kt
+++ b/src/test/kotlin/com/exemplo/demo/controller/SaudacaoControllerTest.kt
@@ -1,0 +1,33 @@
+package com.exemplo.demo.controller
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SaudacaoControllerTest(@Autowired val mockMvc: MockMvc) {
+
+    @Test
+    fun `resposta padrao em ingles quando lang nao informado`() {
+        mockMvc.get("/api/saudacao")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.message") { value("Hello, Dev!") }
+            }
+    }
+
+    @Test
+    fun `resposta em portugues quando lang igual pt`() {
+        mockMvc.get("/api/saudacao") { param("lang", "pt") }
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.message") { value("Olá, Dev!") }
+            }
+    }
+}


### PR DESCRIPTION
## Summary
- add MockMvc tests for SaudacaoController covering default English greeting
- verify Portuguese greeting when `lang=pt`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a598ca14e483229b13582382a6058c