### PR TITLE
Add multi-stage Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+target/
+.git/
+.gitignore
+.github/
+.idea/
+*.iml
+mvnw
+mvnw.cmd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+
+# ----- Build stage -----
+FROM maven:3.9.5-eclipse-temurin-17 AS builder
+WORKDIR /workspace
+COPY pom.xml ./
+COPY src ./src
+RUN mvn package -DskipTests
+
+# ----- Runtime stage -----
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+COPY --from=builder /workspace/target/demo-0.0.1-SNAPSHOT.jar /app/app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app/app.jar"]


### PR DESCRIPTION
## Summary
- create Dockerfile with Maven build stage and Temurin runtime
- add dockerignore to trim build context

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a599528c148322be66473ca2398070