### PR TITLE
docs: add Docker usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,17 @@ mvn -U clean package -DskipTests
 mvn spring-boot:run
 ```
 
+### Docker
+
+Há um `Dockerfile` na raiz do projeto.
+
+```bash
+docker build -t kotlin-i18n-rest-2025 .
+docker run -p 8080:8080 kotlin-i18n-rest-2025
+```
+
+Para encerrar o container, pressione `Ctrl+C` ou execute `docker stop <container>`.
+
 ---
 
 ## 4) Testes (i18n)


### PR DESCRIPTION
## Summary
- document Docker usage: build, run, and stop container

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a67c06fe2c8322ace26fd768e0d9c5