### PR TITLE
docs: add Docker section

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,16 @@ Use o zip já configurado (abra no IntelliJ):
 mvn -U clean package -DskipTests
 mvn spring-boot:run
 
+### Docker
+A `Dockerfile` está na raiz do projeto.
+
+```bash
+docker build -t kotlin-i18n-rest-2025 .
+docker run -p 8080:8080 kotlin-i18n-rest-2025
+```
+
+Para encerrar o container, use `Ctrl+C` ou `docker stop <container>`.
+
 ## Testes
 curl http://localhost:8080/api/saudacao
 curl "http://localhost:8080/api/saudacao?lang=pt"


### PR DESCRIPTION
## Summary
- document Dockerfile usage and sample build/run commands

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.3 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a59f0dce2c8322839c1efda7dcd3d9