### PR TITLE
docs: add AWS deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,3 +257,6 @@ curl http://localhost:8080/api/saudacao
 curl "http://localhost:8080/api/saudacao?lang=pt"
 curl -X POST http://localhost:8080/api/users -H "Content-Type: application/json" -d "{\"name\":\"\",\"email\":\"x\"}"
 curl -X POST "http://localhost:8080/api/users?lang=pt" -H "Content-Type: application/json" -d "{\"name\":\"\",\"email\":\"x\"}"
+
+## 6) Deploy AWS
+Consulte o [guia de deploy na AWS](docs/deploy-aws.md).

--- a/docs/deploy-aws.md
+++ b/docs/deploy-aws.md
@@ -1,0 +1,74 @@
+# Deploy AWS
+
+Guia rápido para empacotar o projeto e publicar uma imagem Docker na AWS usando **ECR** e **ECS Fargate** (ou **Elastic Beanstalk**).
+
+---
+
+## 1) Empacotar o projeto
+
+### Via Maven (JAR)
+```bash
+mvn -U clean package -DskipTests
+```
+O artefato final fica em `target/demo-0.0.1-SNAPSHOT.jar`.
+
+### Via Docker
+```bash
+# gerar JAR e montar imagem
+mvn -U clean package -DskipTests
+docker build -t kotlin-i18n-rest:latest .
+```
+
+---
+
+## 2) Repositório no Amazon ECR
+
+1. Autentique o CLI e selecione a região:
+   ```bash
+   aws configure
+   ```
+2. Crie o repositório:
+   ```bash
+   aws ecr create-repository --repository-name kotlin-i18n-rest
+   ```
+3. Faça login no registro:
+   ```bash
+   aws ecr get-login-password --region <REGIAO> \
+     | docker login --username AWS --password-stdin <AWS_ACCOUNT_ID>.dkr.ecr.<REGIAO>.amazonaws.com
+   ```
+
+---
+
+## 3) Enviar a imagem
+```bash
+docker tag kotlin-i18n-rest:latest \
+  <AWS_ACCOUNT_ID>.dkr.ecr.<REGIAO>.amazonaws.com/kotlin-i18n-rest:latest
+docker push <AWS_ACCOUNT_ID>.dkr.ecr.<REGIAO>.amazonaws.com/kotlin-i18n-rest:latest
+```
+
+---
+
+## 4) Executar na AWS
+
+### Opção A: ECS Fargate
+1. Crie um **Cluster** Fargate no console do ECS.
+2. Defina uma **Task Definition** com o container apontando para a imagem do ECR.
+3. Crie um **Service** ligado ao cluster, escolhendo sub-redes e security groups.
+4. Acesse o endpoint público gerado pelo load balancer (se configurado).
+
+### Opção B: Elastic Beanstalk
+1. Instale o EB CLI (`pip install awsebcli`).
+2. Inicialize o ambiente:
+   ```bash
+   eb init -p docker kotlin-i18n-rest
+   ```
+3. Crie e publique o ambiente:
+   ```bash
+   eb create kotlin-i18n-rest-env
+   eb deploy
+   ```
+4. Abra a URL fornecida pelo Beanstalk.
+
+---
+
+Pronto! O serviço Kotlin/Spring Boot estará disponível na infraestrutura AWS escolhida.


### PR DESCRIPTION
## Summary
- document packaging, ECR setup, and ECS/Beanstalk deployment steps
- link README to AWS deployment guide

## Testing
- `mvn -q -U clean package -DskipTests` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a40bc6588322b18a1c7b02b28922