### PR TITLE
docs: adicionar seção de resiliência no guia de deploy AWS

### DIFF
--- a/docs/deploy-aws.md
+++ b/docs/deploy-aws.md
@@ -1,0 +1,10 @@
+# Deploy na AWS
+
+## Resiliência
+
+Para garantir alta disponibilidade e rápida recuperação de falhas:
+
+- Utilize múltiplas zonas de disponibilidade para evitar pontos únicos de falha.
+- Configure backups automatizados dos dados críticos.
+- Implemente health checks para monitorar e reiniciar instâncias problemáticas.
+


### PR DESCRIPTION
## Summary
- criar docs/deploy-aws.md com subseção de Resiliência
- orientações sobre múltiplas AZs, backups automatizados e health checks

## Testing
- `mvn -q test` *(falhou: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.3: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68a5a40eabe48322a4092f7d2d873164