### PR TITLE
docs: adicionar seção de escalabilidade no guia AWS

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -1,0 +1,21 @@
+# Guia AWS
+
+## Escalabilidade
+
+Aplicações em produção precisam se adaptar a picos de tráfego e quedas de demanda. A AWS oferece recursos nativos para escalar de forma automática e integrar com serviços gerenciados.
+
+### Auto Scaling Groups
+- Defina um *Launch Template* ou *Launch Configuration* com a AMI e tamanho das instâncias.
+- Especifique a quantidade mínima, desejada e máxima de instâncias.
+- Configure políticas de escala com métricas do CloudWatch (ex.: CPU, requisições por segundo).
+- Associe o ASG a sub-redes privadas e, quando necessário, a *Load Balancers*.
+
+### Balanceadores de Carga (ALB)
+- Crie um Application Load Balancer em sub-redes públicas e associe *target groups* que apontam para o Auto Scaling Group.
+- Configure *listeners* (HTTP/HTTPS) e *health checks* para remover instâncias não saudáveis.
+- Habilite *sticky sessions* ou HTTPS offload conforme a necessidade da aplicação.
+
+### Integrações com serviços gerenciados
+- **RDS**: utilize um banco relacional gerenciado; configure *security groups* e parâmetros de conexão para que as instâncias no ASG acessem o endpoint do banco.
+- **ElastiCache**: adicione camadas de cache com Redis ou Memcached; exponha o endpoint nos ambientes e ajuste políticas de segurança para liberar o acesso.
+- Combine esses serviços com o Auto Scaling para que novas instâncias já iniciem configuradas com os endpoints e credenciais corretos.


### PR DESCRIPTION
## Summary
- adicionar seção de escalabilidade ao guia AWS com orientações sobre Auto Scaling Groups, ALB e integrações com RDS/ElastiCache

## Testing
- `mvn test` *(fails: Non-resolvable parent POM: org.springframework.boot:spring-boot-starter-parent:pom:3.3.3)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a40fe75c8322bf4b7c789b90a858