### PR TITLE
feat: configure security and cors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
 
         <!-- Kotlin libs -->
         <dependency>

--- a/src/main/kotlin/com/exemplo/demo/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/exemplo/demo/config/SecurityConfig.kt
@@ -1,0 +1,37 @@
+package com.exemplo.demo.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig {
+
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .cors { }
+            .csrf { csrf -> csrf.disable() }
+            .authorizeHttpRequests { it.anyRequest().permitAll() }
+        return http.build()
+    }
+
+    @Bean
+    fun corsConfigurationSource(): CorsConfigurationSource {
+        val configuration = CorsConfiguration().apply {
+            allowedOrigins = listOf("http://allowed-origin.com")
+            allowedMethods = listOf("GET", "POST")
+            allowedHeaders = listOf("*")
+            allowCredentials = true
+        }
+        val source = UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/**", configuration)
+        return source
+    }
+}


### PR DESCRIPTION
## Summary
- add Spring Security dependency
- add SecurityConfig with restricted CORS and disabled CSRF for stateless API

## Testing
- `mvn -q test` *(fails: Network is unreachable when resolving dependencies)*
- `mvn -q spring-boot:run` *(fails: Network is unreachable when resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a5aa8cf100832295bbac0a855457b1