### PR TITLE
Add retry support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,15 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
+
         <!-- Kotlin libs -->
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/src/main/kotlin/com/exemplo/demo/Application.kt
+++ b/src/main/kotlin/com/exemplo/demo/Application.kt
@@ -2,7 +2,9 @@ package com.exemplo.demo
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.retry.annotation.EnableRetry
 
+@EnableRetry
 @SpringBootApplication(proxyBeanMethods = false)
 class Application {
     companion object {

--- a/src/main/kotlin/com/exemplo/demo/controller/SaudacaoController.kt
+++ b/src/main/kotlin/com/exemplo/demo/controller/SaudacaoController.kt
@@ -6,15 +6,19 @@ import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
 import com.exemplo.demo.dto.UserDto
+import com.exemplo.demo.service.SaudacaoService
 
 @RestController
 @RequestMapping("/api")
-class SaudacaoController(private val messages: MessageSource) {
+class SaudacaoController(
+    private val messages: MessageSource,
+    private val saudacaoService: SaudacaoService
+) {
 
     @GetMapping("/saudacao")
     fun saudacao(@RequestParam(required = false) nome: String?): Map<String, Any> {
         val locale = LocaleContextHolder.getLocale()
-        val hello = messages.getMessage("saudacao.hello", arrayOf(nome ?: "Dev"), locale)
+        val hello = saudacaoService.obterSaudacao(nome)
         return mapOf("message" to hello, "locale" to locale.toLanguageTag())
     }
 

--- a/src/main/kotlin/com/exemplo/demo/service/SaudacaoService.kt
+++ b/src/main/kotlin/com/exemplo/demo/service/SaudacaoService.kt
@@ -1,0 +1,27 @@
+package com.exemplo.demo.service
+
+import org.springframework.context.MessageSource
+import org.springframework.context.i18n.LocaleContextHolder
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Recover
+import org.springframework.retry.annotation.Retryable
+import org.springframework.stereotype.Service
+
+@Service
+class SaudacaoService(private val messages: MessageSource) {
+
+    @Retryable(value = [RuntimeException::class], maxAttempts = 3, backoff = Backoff(delay = 500))
+    fun obterSaudacao(nome: String?): String {
+        if (nome == "erro") {
+            throw RuntimeException("Falha simulada")
+        }
+        val locale = LocaleContextHolder.getLocale()
+        return messages.getMessage("saudacao.hello", arrayOf(nome ?: "Dev"), locale)
+    }
+
+    @Recover
+    fun recuperar(e: RuntimeException, nome: String?): String {
+        val locale = LocaleContextHolder.getLocale()
+        return messages.getMessage("saudacao.hello", arrayOf("Dev"), locale)
+    }
+}


### PR DESCRIPTION
## Summary
- add Spring Retry dependencies and enable retry
- implement SaudacaoService with retry and recovery logic
- wire SaudacaoController to use retryable service

## Testing
- `mvn -q test` *(fails: Network is unreachable to Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b1e73f408322be8c49d6dfddc11c