### PR TITLE
Add Docker and compose configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM maven:3.9-eclipse-temurin-17 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn -q -e -DskipTests package
+
+# Runtime stage
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+COPY --from=build /app/target/demo-0.0.1-SNAPSHOT.jar demo-0.0.1-SNAPSHOT.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","demo-0.0.1-SNAPSHOT.jar"]

--- a/README.md
+++ b/README.md
@@ -252,6 +252,9 @@ Use o zip já configurado (abra no IntelliJ):
 mvn -U clean package -DskipTests
 mvn spring-boot:run
 
+## Docker
+docker compose up --build
+
 ## Testes
 curl http://localhost:8080/api/saudacao
 curl "http://localhost:8080/api/saudacao?lang=pt"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.8"
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      SPRING_PROFILES_ACTIVE: prod


### PR DESCRIPTION
## Summary
- containerize Spring Boot app with multi-stage Dockerfile
- add docker-compose service mapping port 8080
- document docker compose usage in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.3)*

------
https://chatgpt.com/codex/tasks/task_e_68a66db224b083228e5b337642a923df