### PR TITLE
Integra testes BDD com Cucumber

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,30 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>7.18.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-kotlin</artifactId>
+            <version>7.18.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-junit-platform-engine</artifactId>
+            <version>7.18.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-spring</artifactId>
+            <version>7.18.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -147,6 +171,11 @@
                 <configuration>
                     <mainClass>com.exemplo.demo.Application</mainClass>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
             </plugin>
         </plugins>
     </build>

--- a/src/test/kotlin/com/exemplo/demo/cucumber/CucumberTest.kt
+++ b/src/test/kotlin/com/exemplo/demo/cucumber/CucumberTest.kt
@@ -1,0 +1,10 @@
+package com.exemplo.demo.cucumber
+
+import io.cucumber.junit.platform.engine.Cucumber
+import io.cucumber.spring.CucumberContextConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+
+@Cucumber
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@CucumberContextConfiguration
+class CucumberTest

--- a/src/test/kotlin/com/exemplo/demo/cucumber/SaudacaoSteps.kt
+++ b/src/test/kotlin/com/exemplo/demo/cucumber/SaudacaoSteps.kt
@@ -1,0 +1,28 @@
+package com.exemplo.demo.cucumber
+
+import io.cucumber.java8.En
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.http.ResponseEntity
+import kotlin.test.assertEquals
+
+class SaudacaoSteps : En {
+
+    @Autowired
+    lateinit var restTemplate: TestRestTemplate
+
+    private lateinit var response: ResponseEntity<Map<String, Any>>
+
+    init {
+        When("realizo uma requisição GET para {string}") { url: String ->
+            @Suppress("UNCHECKED_CAST")
+            response = restTemplate.getForEntity(url, Map::class.java) as ResponseEntity<Map<String, Any>>
+        }
+        Then("o status deve ser {int}") { status: Int ->
+            assertEquals(status, response.statusCode.value())
+        }
+        Then("a mensagem deve ser {string}") { mensagem: String ->
+            assertEquals(mensagem, response.body?.get("message"))
+        }
+    }
+}

--- a/src/test/resources/features/saudacao.feature
+++ b/src/test/resources/features/saudacao.feature
@@ -1,0 +1,7 @@
+# language: pt
+Funcionalidade: Saudação
+
+  Cenário: saudação padrão
+    Quando realizo uma requisição GET para "/api/saudacao?lang=pt_BR"
+    Então o status deve ser 200
+    E a mensagem deve ser "Olá, Dev!"


### PR DESCRIPTION
## Summary
- configura Cucumber e Maven Surefire para JUnit Platform
- adiciona cenário de saudação com steps e runner Spring Boot

## Testing
- `mvn test` *(falhou: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.3 from/to central)*

------
https://chatgpt.com/codex/tasks/task_e_68a6807a50208322905202a995958c9c