### PR TITLE
fix: make security config open

### DIFF
--- a/src/main/kotlin/com/exemplo/demo/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/exemplo/demo/config/SecurityConfig.kt
@@ -17,10 +17,10 @@ import org.springframework.security.provisioning.InMemoryUserDetailsManager
 @Configuration
 @EnableMethodSecurity
 @EnableWebSecurity
-class SecurityConfig {
+open class SecurityConfig {
 
     @Bean
-    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+    open fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
             .cors { }
             .csrf { csrf -> csrf.disable() }
@@ -37,7 +37,7 @@ class SecurityConfig {
     }
 
     @Bean
-    fun corsConfigurationSource(): CorsConfigurationSource {
+    open fun corsConfigurationSource(): CorsConfigurationSource {
         val configuration = CorsConfiguration().apply {
             allowedOrigins = listOf("http://allowed-origin.com")
             allowedMethods = listOf("GET", "POST")
@@ -49,7 +49,7 @@ class SecurityConfig {
         return source
     }
 
-    fun users(): UserDetailsService {
+    open fun users(): UserDetailsService {
         val user = User.withUsername("user").password("{noop}password").roles("USER").build()
         val admin = User.withUsername("admin").password("{noop}admin").roles("ADMIN").build()
         return InMemoryUserDetailsManager(user, admin)


### PR DESCRIPTION
## Summary
- allow Spring to create proxies for security configuration by opening the configuration class and its bean methods

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.exemplo:demo:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68a76455213c8322b5b29fadace2d528