### PR TITLE
Fix proxying error in SaudacaoService

### DIFF
--- a/src/main/kotlin/com/exemplo/demo/service/SaudacaoService.kt
+++ b/src/main/kotlin/com/exemplo/demo/service/SaudacaoService.kt
@@ -8,10 +8,10 @@ import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Service
 
 @Service
-class SaudacaoService(private val messages: MessageSource) {
+open class SaudacaoService(private val messages: MessageSource) {
 
     @Retryable(value = [RuntimeException::class], maxAttempts = 3, backoff = Backoff(delay = 500))
-    fun obterSaudacao(nome: String?): String {
+    open fun obterSaudacao(nome: String?): String {
         if (nome == "erro") {
             throw RuntimeException("Falha simulada")
         }
@@ -20,7 +20,7 @@ class SaudacaoService(private val messages: MessageSource) {
     }
 
     @Recover
-    fun recuperar(e: RuntimeException, nome: String?): String {
+    open fun recuperar(e: RuntimeException, nome: String?): String {
         val locale = LocaleContextHolder.getLocale()
         return messages.getMessage("saudacao.hello", arrayOf("Dev"), locale)
     }


### PR DESCRIPTION
## Summary
- make SaudacaoService and its methods `open` so Spring can create CGLIB proxies for retry logic

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a76a67a59083229ac449031eb23ae1