### PR TITLE
Allow proxying SaudacaoController

### DIFF
--- a/src/main/kotlin/com/exemplo/demo/controller/SaudacaoController.kt
+++ b/src/main/kotlin/com/exemplo/demo/controller/SaudacaoController.kt
@@ -13,14 +13,14 @@ import com.exemplo.demo.service.SaudacaoService
 
 @RestController
 @RequestMapping("/api")
-class SaudacaoController(
+open class SaudacaoController(
     private val messages: MessageSource,
     private val saudacaoService: SaudacaoService
 ) {
 
     @GetMapping("/saudacao")
     @PreAuthorize("hasAnyRole('USER','ADMIN')")
-    fun saudacao(
+    open fun saudacao(
         @RequestParam(required = false) nome: String?,
         authentication: Authentication
     ): Map<String, Any> {
@@ -32,7 +32,7 @@ class SaudacaoController(
 
     @PostMapping("/users")
     @PreAuthorize("hasRole('ADMIN')")
-    fun create(@Validated @RequestBody dto: UserDto): ResponseEntity<Any> {
+    open fun create(@Validated @RequestBody dto: UserDto): ResponseEntity<Any> {
         val locale = LocaleContextHolder.getLocale()
         val msg = messages.getMessage("user.created", arrayOf(dto.name), locale)
         return ResponseEntity.ok(mapOf("message" to msg))


### PR DESCRIPTION
## Summary
- make SaudacaoController and its endpoints open so Spring can create proxies

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a76b8c3abc8322a597a5de25286533